### PR TITLE
Set filter = True in goodJets module

### DIFF
--- a/EDBRCommon/plugins/TrigReportData.cc
+++ b/EDBRCommon/plugins/TrigReportData.cc
@@ -40,15 +40,16 @@ TrigReportData::TrigReportData(const edm::ParameterSet& iConfig):
   trigResult_(consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("trigResult")))
 {
   edm::Service<TFileService> fs;
-  cutFlow = fs->make<TH1I>("cutFlow","", 7, 0, 7);
+  cutFlow = fs->make<TH1I>("cutFlow","", 8, 0, 8);
   TAxis *axis = cutFlow->GetXaxis();  
   axis->SetBinLabel(1,"Begin");
   axis->SetBinLabel(2,"HLT");
   axis->SetBinLabel(3,"Vertex");
   axis->SetBinLabel(4,"Leptons");
   axis->SetBinLabel(5,"Dilepton");
-  axis->SetBinLabel(6,"V-jet");
-  axis->SetBinLabel(7,"Graviton");
+  axis->SetBinLabel(6,"JetID");
+  axis->SetBinLabel(7,"JetClean");
+  axis->SetBinLabel(8,"Graviton");
 
   evTree = fs->make<TTree>("evTree", "basic event information");
   evTree->Branch("run",          &run,          "run/I");
@@ -78,9 +79,10 @@ void TrigReportData::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       case  5: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); break;
       case 14: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); cutFlow->Fill("Vertex",1); break;
       case 15: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); cutFlow->Fill("Vertex",1); cutFlow->Fill("Leptons",1); break;
-      case 21: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); cutFlow->Fill("Vertex",1); cutFlow->Fill("Leptons",1); cutFlow->Fill("Dilepton",1); break;
-      case 24: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); cutFlow->Fill("Vertex",1); cutFlow->Fill("Leptons",1); cutFlow->Fill("Dilepton",1); cutFlow->Fill("V-jet",1); break;
-      case 25: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); cutFlow->Fill("Vertex",1); cutFlow->Fill("Leptons",1); cutFlow->Fill("Dilepton",1); cutFlow->Fill("V-jet",1); cutFlow->Fill("Graviton",1); break;
+      case 18: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); cutFlow->Fill("Vertex",1); cutFlow->Fill("Leptons",1); cutFlow->Fill("Dilepton",1); break;
+      case 20: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); cutFlow->Fill("Vertex",1); cutFlow->Fill("Leptons",1); cutFlow->Fill("Dilepton",1); cutFlow->Fill("JetID",1); break;
+      case 23: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); cutFlow->Fill("Vertex",1); cutFlow->Fill("Leptons",1); cutFlow->Fill("Dilepton",1); cutFlow->Fill("JetID",1); cutFlow->Fill("JetClean",1); break;
+      case 24: cutFlow->Fill("Begin",1); cutFlow->Fill("HLT",1); cutFlow->Fill("Vertex",1); cutFlow->Fill("Leptons",1); cutFlow->Fill("Dilepton",1); cutFlow->Fill("JetID",1); cutFlow->Fill("JetClean",1); cutFlow->Fill("Graviton",1); break;
   }
 }
 

--- a/EDBRCommon/python/goodJets_cff.py
+++ b/EDBRCommon/python/goodJets_cff.py
@@ -3,8 +3,8 @@ from PhysicsTools.SelectorUtils.pfJetIDSelector_cfi import pfJetIDSelector
 
 goodJets = cms.EDFilter("PFJetIDSelectionFunctorFilter",
                         filterParams = pfJetIDSelector.clone(),
-                        src = cms.InputTag("slimmedJetsAK8")
-                        )
+                        src = cms.InputTag("slimmedJetsAK8"),
+                        filter = cms.bool(True) )
 
 ### Cleaning
 # We want to make sure that the jets are not the electrons or muons done previously

--- a/EDBRGenStudies/plugins/TrigReportAnalyzer.cc
+++ b/EDBRGenStudies/plugins/TrigReportAnalyzer.cc
@@ -46,24 +46,26 @@ TrigReportAnalyzer::TrigReportAnalyzer(const edm::ParameterSet& iConfig):
   hadronicZ_(iConfig.getParameter<edm::InputTag>("hadronicZ"))
 {
   edm::Service<TFileService> fs;
-  wfMu = fs->make<TH1I>("wfMu","", 7, 0, 7);
-  wfEl = fs->make<TH1I>("wfEl","", 7, 0, 7);
+  wfMu = fs->make<TH1I>("wfMu","", 8, 0, 8);
+  wfEl = fs->make<TH1I>("wfEl","", 8, 0, 8);
   TAxis *axisMu = wfMu->GetXaxis();  
   axisMu->SetBinLabel(1,"Begin");
   axisMu->SetBinLabel(2,"HLT");
   axisMu->SetBinLabel(3,"Vertex");
   axisMu->SetBinLabel(4,"Leptons");
   axisMu->SetBinLabel(5,"Dilepton");
-  axisMu->SetBinLabel(6,"V-jet");
-  axisMu->SetBinLabel(7,"Graviton");
+  axisMu->SetBinLabel(6,"JetID");
+  axisMu->SetBinLabel(7,"JetClean");
+  axisMu->SetBinLabel(8,"Graviton");
   TAxis *axisEl = wfEl->GetXaxis();  
   axisEl->SetBinLabel(1,"Begin");
   axisEl->SetBinLabel(2,"HLT");
   axisEl->SetBinLabel(3,"Vertex");
   axisEl->SetBinLabel(4,"Leptons");
   axisEl->SetBinLabel(5,"Dilepton");
-  axisEl->SetBinLabel(6,"V-jet");
-  axisEl->SetBinLabel(7,"Graviton");
+  axisEl->SetBinLabel(6,"JetID");
+  axisEl->SetBinLabel(7,"JetClean");
+  axisEl->SetBinLabel(8,"Graviton");
 
   genTree = fs->make<TTree>("genTree", "physical variables at GEN level");
   genTree->Branch("run",          &run,          "run/I");
@@ -114,9 +116,10 @@ void TrigReportAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
             case  7: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); break;
             case 16: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); wfMu->Fill("Vertex",1); break;
             case 17: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); wfMu->Fill("Vertex",1); wfMu->Fill("Leptons",1); break;
-            case 23: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); wfMu->Fill("Vertex",1); wfMu->Fill("Leptons",1); wfMu->Fill("Dilepton",1); break;
-            case 26: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); wfMu->Fill("Vertex",1); wfMu->Fill("Leptons",1); wfMu->Fill("Dilepton",1); wfMu->Fill("V-jet",1); break;
-            case 27: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); wfMu->Fill("Vertex",1); wfMu->Fill("Leptons",1); wfMu->Fill("Dilepton",1); wfMu->Fill("V-jet",1); wfMu->Fill("Graviton",1); break;
+            case 20: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); wfMu->Fill("Vertex",1); wfMu->Fill("Leptons",1); wfMu->Fill("Dilepton",1); break;
+            case 22: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); wfMu->Fill("Vertex",1); wfMu->Fill("Leptons",1); wfMu->Fill("Dilepton",1); wfMu->Fill("JetID",1); break;
+            case 25: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); wfMu->Fill("Vertex",1); wfMu->Fill("Leptons",1); wfMu->Fill("Dilepton",1); wfMu->Fill("JetID",1); wfMu->Fill("JetClean",1); break;
+            case 26: wfMu->Fill("Begin",1); wfMu->Fill("HLT",1); wfMu->Fill("Vertex",1); wfMu->Fill("Leptons",1); wfMu->Fill("Dilepton",1); wfMu->Fill("JetID",1); wfMu->Fill("JetClean",1); wfMu->Fill("Graviton",1); break;
         }
      }
      // cut flow for electrons
@@ -126,9 +129,10 @@ void TrigReportAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
             case  7: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); break;
             case 16: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); wfEl->Fill("Vertex",1); break;
             case 17: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); wfEl->Fill("Vertex",1); wfEl->Fill("Leptons",1); break;
-            case 23: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); wfEl->Fill("Vertex",1); wfEl->Fill("Leptons",1); wfEl->Fill("Dilepton",1); break;
-            case 26: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); wfEl->Fill("Vertex",1); wfEl->Fill("Leptons",1); wfEl->Fill("Dilepton",1); wfEl->Fill("V-jet",1); break;
-            case 27: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); wfEl->Fill("Vertex",1); wfEl->Fill("Leptons",1); wfEl->Fill("Dilepton",1); wfEl->Fill("V-jet",1); wfEl->Fill("Graviton",1); break;
+            case 20: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); wfEl->Fill("Vertex",1); wfEl->Fill("Leptons",1); wfEl->Fill("Dilepton",1); break;
+            case 22: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); wfEl->Fill("Vertex",1); wfEl->Fill("Leptons",1); wfEl->Fill("Dilepton",1); wfEl->Fill("JetID",1); break;
+            case 25: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); wfEl->Fill("Vertex",1); wfEl->Fill("Leptons",1); wfEl->Fill("Dilepton",1); wfEl->Fill("JetID",1); wfEl->Fill("JetClean",1); break;
+            case 26: wfEl->Fill("Begin",1); wfEl->Fill("HLT",1); wfEl->Fill("Vertex",1); wfEl->Fill("Leptons",1); wfEl->Fill("Dilepton",1); wfEl->Fill("JetID",1); wfEl->Fill("JetClean",1); wfEl->Fill("Graviton",1); break;
         }
      }
    }

--- a/EDBRTreeMaker/backgrounds/TTbar/analysis50ns-TT.py
+++ b/EDBRTreeMaker/backgrounds/TTbar/analysis50ns-TT.py
@@ -55,11 +55,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -116,7 +111,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-100to200.py
+++ b/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-100to200.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-200to400.py
+++ b/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-200to400.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-400to600.py
+++ b/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-400to600.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-600toInf.py
+++ b/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-600toInf.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis-TT.py
+++ b/EDBRTreeMaker/backgrounds/analysis-TT.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis-WW.py
+++ b/EDBRTreeMaker/backgrounds/analysis-WW.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis-WZ.py
+++ b/EDBRTreeMaker/backgrounds/analysis-WZ.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis-ZZ.py
+++ b/EDBRTreeMaker/backgrounds/analysis-ZZ.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-100to200.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-100to200.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-200to400.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-200to400.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-400to600.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-400to600.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-600toInf.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-600toInf.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis50ns-TT.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-TT.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis50ns-WW.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-WW.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis50ns-WZ.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-WZ.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/backgrounds/analysis50ns-ZZ.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-ZZ.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/data/analysis-SingleElectron_Run2015B.py
+++ b/EDBRTreeMaker/data/analysis-SingleElectron_Run2015B.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/data/analysis-SingleMuon_Run2015B.py
+++ b/EDBRTreeMaker/data/analysis-SingleMuon_Run2015B.py
@@ -72,11 +72,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -133,7 +128,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1000.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1000.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1200.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1200.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1400.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1400.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1600.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1600.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1800.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1800.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-2000.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-2000.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-2500.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-2500.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-3000.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-3000.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-3500.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-3500.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-4000.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-4000.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-4500.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-4500.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-600.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-600.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-800.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-800.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1000.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1000.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1200.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1200.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1400.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1400.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1600.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1600.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1800.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1800.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-2000.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-2000.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-2500.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-2500.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-3000.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-3000.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-3500.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-3500.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-4000.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-4000.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-4500.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-4500.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-600.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-600.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-800.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-800.py
@@ -99,11 +99,6 @@ process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
 
-process.hadronicVFilter = cms.EDFilter(   "CandViewCountFilter",
-                                          src = cms.InputTag("hadronicV"),
-                                          minNumber = cms.uint32(1),
-                                          filter = cms.bool(True) )
-
 process.bestHadronicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("hadronicV"),
                                           maxNumber = cms.uint32(1) )
@@ -160,7 +155,6 @@ process.leptonSequence = cms.Sequence(    process.leptonicVSequence +
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence   +
                                           process.hadronicV         +
-                                          process.hadronicVFilter   +
                                           process.bestHadronicV     )
 
 process.gravitonSequence = cms.Sequence(  process.graviton          +


### PR DESCRIPTION
This flag is helpful to study the efficiency of the [JetID](https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID).
We are also removing the hadronicVFilter module, since the previous selector in the sequence (hadronicV) is already asking the existence of one cleanJet.
