### PR TITLE
Skip error in egmGsfElectronIDs for latest 74X

### DIFF
--- a/EDBRTreeMaker/backgrounds/TTbar/analysis50ns-TT.py
+++ b/EDBRTreeMaker/backgrounds/TTbar/analysis50ns-TT.py
@@ -131,7 +131,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-100to200.py
+++ b/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-100to200.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-200to400.py
+++ b/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-200to400.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-400to600.py
+++ b/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-400to600.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-600toInf.py
+++ b/EDBRTreeMaker/backgrounds/analysis-DYJetsToLL_HT-600toInf.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis-TT.py
+++ b/EDBRTreeMaker/backgrounds/analysis-TT.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis-WW.py
+++ b/EDBRTreeMaker/backgrounds/analysis-WW.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis-WZ.py
+++ b/EDBRTreeMaker/backgrounds/analysis-WZ.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis-ZZ.py
+++ b/EDBRTreeMaker/backgrounds/analysis-ZZ.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-100to200.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-100to200.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-200to400.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-200to400.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-400to600.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-400to600.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-600toInf.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-DYJetsToLL_HT-600toInf.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis50ns-TT.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-TT.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis50ns-WW.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-WW.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis50ns-WZ.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-WZ.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/backgrounds/analysis50ns-ZZ.py
+++ b/EDBRTreeMaker/backgrounds/analysis50ns-ZZ.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/data/analysis-SingleElectron_Run2015B.py
+++ b/EDBRTreeMaker/data/analysis-SingleElectron_Run2015B.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/data/analysis-SingleMuon_Run2015B.py
+++ b/EDBRTreeMaker/data/analysis-SingleMuon_Run2015B.py
@@ -148,7 +148,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1000.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1000.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1200.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1200.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1400.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1400.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1600.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1600.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-1800.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-1800.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-2000.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-2000.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-2500.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-2500.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-3000.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-3000.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-3500.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-3500.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-4000.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-4000.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-4500.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-4500.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-600.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-600.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis-BulkGrav_M-800.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav_M-800.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1000.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1000.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1200.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1200.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1400.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1400.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1600.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1600.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1800.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-1800.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-2000.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-2000.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-2500.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-2500.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-3000.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-3000.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-3500.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-3500.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-4000.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-4000.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-4500.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-4500.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-600.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-600.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-800.py
+++ b/EDBRTreeMaker/test/analysis50ns-BulkGrav_M-800.py
@@ -175,7 +175,7 @@ if option=='RECO':
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
     process.analysis.replace(process.leptonSequence, 
                              process.hltSequence              +
-                             process.egmGsfElectronIDSequence + 
+                             process.egmGsfElectronIDs        + 
                              process.goodLeptonsProducer      +  
                              process.leptonSequence           ) 
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Instructions to setup the ExoDiBosonResonances code
 ========
 
 ```
-cmsrel CMSSW_7_4_10_patch2
-cd CMSSW_7_4_10_patch2/src
+cmsrel CMSSW_7_4_12
+cd CMSSW_7_4_12/src
 cmsenv
 git cms-init # This will allow you to checkout packages in official CMSSW
 git clone -b Analysis74X git@github.com:cms-edbr/ExoDiBosonResonancesRun2.git ExoDiBosonResonances


### PR DESCRIPTION
In latest 74X releases, [egmGsfElectronIDSequence](https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/RecoEgamma/ElectronIdentification/python/egmGsfElectronIDs_cff.py#L12) includes module [electronRegressionValueMapProducer](https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/RecoEgamma/ElectronIdentification/python/ElectronRegressionValueMapProducer_cfi.py). That module is causing a Fatal Exception:

----- Begin Fatal Exception 10-Sep-2015 14:34:14 BRT-----------------------
An exception of category 'InvalidReference' occurred while
   [0] Processing run: 1 lumi: 3 event: 401
   [1] Running path 'analysis'
   [2] Calling event method for module ElectronRegressionValueMapProducer/'electronRegressionValueMapProducer'
Exception Message:
Asked for data from a PtrVector which refers to a non-existent product with ProductID 4:724
----- End Fatal Exception -------------------------------------------------

This commit remove that module from our analysis path to skip the Fatal Exception.
