### PR TITLE
Adding jet rho ratio

### DIFF
--- a/EDBRTreeMaker/plugins/EDBRTreeMaker.cc
+++ b/EDBRTreeMaker/plugins/EDBRTreeMaker.cc
@@ -80,6 +80,7 @@ private:
   double tau1,      tau2,     tau3,       tau21;
   double etjet1,    ptjet1,   etajet1,    phijet1;
   double massjet1,  softjet1, prunedjet1;
+  double rhojet1;                  // SRR : Jet Rho Ratio (m/pt*R)^2
   double nhfjet1,   chfjet1;       // neutral and charged hadron energy fraction
   double nemfjet1,  cemfjet1;      // neutral and charged EM fraction
   int    nmultjet1, cmultjet1;     // neutral and charged multiplicity
@@ -288,6 +289,7 @@ EDBRTreeMaker::EDBRTreeMaker(const edm::ParameterSet& iConfig):
   outTree_->Branch("ptlep2"          ,&ptlep2         ,"ptlep2/D"         );
   outTree_->Branch("ptjet1"          ,&ptjet1         ,"ptjet1/D"         );
   outTree_->Branch("etjet1"          ,&etjet1         ,"etjet1/D"         );
+  outTree_->Branch("rhojet1"         ,&rhojet1        ,"rhojet1/D"        );
   outTree_->Branch("etalep1"         ,&etalep1        ,"etalep1/D"        );
   outTree_->Branch("etalep2"         ,&etalep2        ,"etalep2/D"        );
   outTree_->Branch("etajet1"         ,&etajet1        ,"etajet1/D"        );
@@ -300,6 +302,8 @@ EDBRTreeMaker::EDBRTreeMaker(const edm::ParameterSet& iConfig):
   outTree_->Branch("met"             ,&met            ,"met/D"            );
   outTree_->Branch("metpt"           ,&metpt          ,"metpt/D"          );
   outTree_->Branch("metPhi"          ,&metPhi         ,"metPhi/D"         );
+  
+
 
   // Other quantities
   outTree_->Branch("triggerWeight"   ,&triggerWeight  ,"triggerWeight/D"  );
@@ -414,6 +418,13 @@ void EDBRTreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
                    softjet1       = hadronicV.userFloat("ak8PFJetsCHSSoftDropMass");
                    prunedjet1     = hadronicV.userFloat("ak8PFJetsCHSPrunedMass");
                    massVhad       = hadronicV.userFloat("ak8PFJetsCHSCorrPrunedMass");
+		   // SRR : get rho ratio. This assumes the subjets are corrected to L2L3.
+		   // If not, they must be done on-the-fly with a separate jet corrector. 
+		   auto subjetsSD = hadronicV.subjets("SoftDrop");
+		   if ( subjetsSD.size() >= 2 ) {
+		     auto groomedJet = subjetsSD[0]->p4() + subjetsSD[1]->p4();
+		     rhojet1 = std::pow( groomedJet.mass() / (groomedJet.pt() * 0.8), 2.0);		     
+		   }
                    //*****************************************************************//
                    //***************************** Jet ID ****************************//
                    //*****************************************************************//
@@ -709,6 +720,7 @@ void EDBRTreeMaker::setDummyValues() {
      massjet1       = -1e4;
      softjet1       = -1e4;
      prunedjet1     = -1e4;
+     rhojet1        = -1e4;
      nhfjet1        = -1e4;
      chfjet1        = -1e4;
      nemfjet1       = -1e4;

--- a/EDBRTreeMaker/promptReco/Run2015D/SingleMuon/analysis-SingleMuon.py
+++ b/EDBRTreeMaker/promptReco/Run2015D/SingleMuon/analysis-SingleMuon.py
@@ -51,7 +51,7 @@ process.hltFilter.triggerConditions =  ( "HLT_Mu45_eta2p1_v*", )
 
 #*********************************** POOL SOURCE ****************************************************#
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100000) )
 process.source = cms.Source ("PoolSource",
     fileNames = cms.untracked.vstring(
          '/store/data/Run2015D/SingleMuon/MINIAOD/PromptReco-v4/000/258/159/00000/6CA1C627-246C-E511-8A6A-02163E014147.root',

--- a/PlottingMacro/EDBRHistoMaker.h
+++ b/PlottingMacro/EDBRHistoMaker.h
@@ -64,6 +64,8 @@ class EDBRHistoMaker {
    Double_t        massVlep;
    Double_t        mtVlep;
    Double_t        massVhad;
+   Double_t        massVhadSD;
+   
    Double_t        tau1;
    Double_t        tau2;
    Double_t        tau3;
@@ -77,6 +79,7 @@ class EDBRHistoMaker {
    Double_t        philep1;
    Double_t        philep2;
    Double_t        phijet1;
+   Double_t        rhojet1;
    Double_t        met;
    Double_t        metPhi;
    Int_t           lep;
@@ -116,6 +119,7 @@ class EDBRHistoMaker {
    TBranch        *b_philep1;   //!
    TBranch        *b_philep2;   //!
    TBranch        *b_phijet1;   //!
+   TBranch        *b_rhojet1;   //!
    TBranch        *b_met;   //!
    TBranch        *b_metPhi;   //!
    TBranch        *b_lep;   //!
@@ -261,6 +265,7 @@ void EDBRHistoMaker::Init(TTree *tree)
    fChain->SetBranchAddress("philep1", &philep1, &b_philep1);
    fChain->SetBranchAddress("philep2", &philep2, &b_philep2);
    fChain->SetBranchAddress("phijet1", &phijet1, &b_phijet1);
+   fChain->SetBranchAddress("rhojet1", &rhojet1, &b_rhojet1);
    fChain->SetBranchAddress("met", &met, &b_met);
    fChain->SetBranchAddress("metPhi", &metPhi, &b_metPhi);
    fChain->SetBranchAddress("lep", &lep, &b_lep);
@@ -352,6 +357,7 @@ void EDBRHistoMaker::createAllHistos() {
   hs.setHisto("philep1",74,-3.7,3.7);
   hs.setHisto("philep2",74,-3.7,3.7);
   hs.setHisto("phijet1",74,-3.7,3.7);
+  hs.setHisto("rhojet1",50,0,1);
   hs.setHisto("lep",30,-0.5,29.5);
   hs.setHisto("region",5,-1.5,3.5); 
   hs.setHisto("triggerWeight",50,0,5); 
@@ -570,6 +576,7 @@ void EDBRHistoMaker::Loop(std::string outFileName){
       (theHistograms["philep1"])->Fill(philep1,actualWeight);//printf("line number %i\n",__LINE__);
       (theHistograms["philep2"])->Fill(philep2,actualWeight);//printf("line number %i\n",__LINE__);
       (theHistograms["phijet1"])->Fill(phijet1,actualWeight);//printf("line number %i\n",__LINE__);
+      (theHistograms["rhojet1"])->Fill(rhojet1,actualWeight);//printf("line number %i\n",__LINE__);
       (theHistograms["ptZll"])->Fill(ptVlep,actualWeight);//printf("line number %i\n",__LINE__);
       (theHistograms["ptZjj"])->Fill(ptVhad,actualWeight);//printf("line number %i\n",__LINE__);
       (theHistograms["phiZll"])->Fill(phiVlep,actualWeight);//printf("line number %i\n",__LINE__);


### PR DESCRIPTION
Adding the jet rho ratio (rho = (m/pt*R)^2) to the ntuples. To use the rho ratio method, see the methodology here:

https://twiki.cern.ch/twiki/bin/view/CMS/ExoDiBosonResonancesRun2#Rho_ratio_based_background_estim
