### PR TITLE
Change vertex collection in Dxy cut

### DIFF
--- a/EDBRCommon/python/goodJets_cff.py
+++ b/EDBRCommon/python/goodJets_cff.py
@@ -24,6 +24,6 @@ cleanJets.checkOverlaps.electrons.requireNoOverlaps = True
 cleanJets.checkOverlaps.photons = cms.PSet()
 cleanJets.checkOverlaps.taus = cms.PSet()
 cleanJets.checkOverlaps.tkIsoElectrons = cms.PSet()
-cleanJets.finalCut = "pt > 20 & abs(eta) < 2.4"
+cleanJets.finalCut = ""
 
 fatJetsSequence = cms.Sequence(bestLeptonicVdaughters + goodJets + cleanJets)

--- a/EDBRCommon/python/goodJets_cff.py
+++ b/EDBRCommon/python/goodJets_cff.py
@@ -26,4 +26,11 @@ cleanJets.checkOverlaps.taus = cms.PSet()
 cleanJets.checkOverlaps.tkIsoElectrons = cms.PSet()
 cleanJets.finalCut = ""
 
-fatJetsSequence = cms.Sequence(bestLeptonicVdaughters + goodJets + cleanJets)
+# module to filter on the number of Jets
+countCleanJets = cms.EDFilter("PATCandViewCountFilter",
+    minNumber = cms.uint32(1),
+    maxNumber = cms.uint32(999999),
+    src = cms.InputTag("cleanJets")
+)
+
+fatJetsSequence = cms.Sequence(bestLeptonicVdaughters + goodJets + cleanJets + countCleanJets)

--- a/EDBRCommon/python/hadronicZ_cff.py
+++ b/EDBRCommon/python/hadronicZ_cff.py
@@ -9,7 +9,7 @@ corrJetsProducer = cms.EDProducer ( "CorrJetsProducer",
 
 hadronicV = cms.EDFilter( "CandViewSelector",
                           src = cms.InputTag("corrJetsProducer:corrJets"),
-                          cut = cms.string('pt > 200. & userFloat("ak8PFJetsCHSCorrPrunedMass") > 5.'),
+                          cut = cms.string('pt > 200. & abs(eta)<2.4'),
                           filter = cms.bool(True) )
 
 hadronicVSequence = cms.Sequence( corrJetsProducer + hadronicV )

--- a/EDBRTreeMaker/backgrounds/analysis-background.py
+++ b/EDBRTreeMaker/backgrounds/analysis-background.py
@@ -117,11 +117,17 @@ my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.heepElectronI
 for idmod in my_id_modules:
     setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
 
+#Change vertex collection in Dxy cut
+process.egmGsfElectronIDs.physicsObjectIDs[0].idDefinition.cutFlow[9].vertexSrcMiniAOD = "goodOfflinePrimaryVertex"
+
 process.leptonSequence = cms.Sequence(    process.hltSequence              +
-                                          process.egmGsfElectronIDs        + 
                                           process.goodLeptonsProducer      +  
                                           process.leptonicVSequence        + 
                                           process.bestLeptonicV            )
+
+process.leptonSequence.replace(           process.goodOfflinePrimaryVertex,
+                                          process.goodOfflinePrimaryVertex +
+                                          process.egmGsfElectronIDs        )
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence          +
                                           process.hadronicVSequence        +

--- a/EDBRTreeMaker/promptReco/Run2015CD/analysis-data.py
+++ b/EDBRTreeMaker/promptReco/Run2015CD/analysis-data.py
@@ -118,11 +118,17 @@ my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.heepElectronI
 for idmod in my_id_modules:
     setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
 
+#Change vertex collection in Dxy cut
+process.egmGsfElectronIDs.physicsObjectIDs[0].idDefinition.cutFlow[9].vertexSrcMiniAOD = "goodOfflinePrimaryVertex"
+
 process.leptonSequence = cms.Sequence(    process.hltSequence              +
-                                          process.egmGsfElectronIDs        + 
                                           process.goodLeptonsProducer      +  
                                           process.leptonicVSequence        + 
                                           process.bestLeptonicV            )
+
+process.leptonSequence.replace(           process.goodOfflinePrimaryVertex,
+                                          process.goodOfflinePrimaryVertex +
+                                          process.egmGsfElectronIDs        )
 
 process.jetSequence = cms.Sequence(       process.fatJetsSequence          +
                                           process.hadronicVSequence        +

--- a/EDBRTreeMaker/test/analysis-BulkGrav.py
+++ b/EDBRTreeMaker/test/analysis-BulkGrav.py
@@ -89,6 +89,9 @@ my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.heepElectronI
 for idmod in my_id_modules:
     setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
 
+#Change vertex collection in Dxy cut
+process.egmGsfElectronIDs.physicsObjectIDs[0].idDefinition.cutFlow[9].vertexSrcMiniAOD = "goodOfflinePrimaryVertex"
+
 process.bestLeptonicV = cms.EDFilter(    "LargestPtCandSelector",
                                           src = cms.InputTag("leptonicVSelector"),
                                           maxNumber = cms.uint32(1) )
@@ -120,7 +123,6 @@ process.treeDumper = cms.EDAnalyzer(     "EDBRTreeMaker",
 
 process.analysis = cms.Path(              process.leptonicDecay            + 
                                           process.hltSequence              +
-                                          process.egmGsfElectronIDs        + 
                                           process.goodLeptonsProducer      +  
                                           process.leptonicVSequence        +
                                           process.bestLeptonicV            +
@@ -131,6 +133,10 @@ process.analysis = cms.Path(              process.leptonicDecay            +
                                           process.graviton                 +
                                           process.gravitonFilter           +
                                           process.treeDumper               )
+
+process.analysis.replace(                 process.goodOfflinePrimaryVertex,
+                                          process.goodOfflinePrimaryVertex +
+                                          process.egmGsfElectronIDs        )
 
 process.load("ExoDiBosonResonances.EDBRGenStudies.trigReportAnalyzer_cff")
 process.endpath = cms.EndPath( process.trigReportAnalyzer )


### PR DESCRIPTION
The dxy cut in HEEPv6 is defined as the closest distance between the electron's gsfTrack and the associated primary vertex. |dxy|<0.02 for EB and |dxy|<0.05 for EE.

With this commit the dxy is re-calculated using the selected good primary vertex instead of the default one from "offlineSlimmedPrimaryVertices"
